### PR TITLE
Line label offset

### DIFF
--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -277,7 +277,7 @@ export class Labeler {
         zoom: this.z,
         scratch: this.scratch,
         order: order,
-        overzoom: this.z - pt.data_tile.z
+        overzoom: this.z - pt.data_tile.z,
       };
       for (let feature of feats) {
         if (rule.filter && !rule.filter(this.z, feature)) continue;

--- a/src/line.ts
+++ b/src/line.ts
@@ -112,17 +112,27 @@ export function simpleLabel(
     let segments = linelabel(ls, Math.PI / 90); // 2 degrees, close to a straight line
     for (let segment of segments) {
       if (segment.length >= minimum + cellSize) {
-        let start = new Point(ls[segment.beginIndex].x,ls[segment.beginIndex].y)
-        let end = ls[segment.endIndex-1]
-        let normalized = new Point((end.x-start.x)/segment.length,(end.y-start.y)/segment.length)
+        let start = new Point(
+          ls[segment.beginIndex].x,
+          ls[segment.beginIndex].y
+        );
+        let end = ls[segment.endIndex - 1];
+        let normalized = new Point(
+          (end.x - start.x) / segment.length,
+          (end.y - start.y) / segment.length
+        );
 
         // offset from the start by cellSize to allow streets that meet at right angles
         // to both be labeled.
-        for (var i = cellSize; i < segment.length - minimum; i += repeatDistance) {
+        for (
+          var i = cellSize;
+          i < segment.length - minimum;
+          i += repeatDistance
+        ) {
           candidates.push({
             start: start.add(normalized.mult(i)),
-            end: start.add(normalized.mult(i+minimum))
-          })
+            end: start.add(normalized.mult(i + minimum)),
+          });
         }
       }
     }

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -862,20 +862,30 @@ export class LineLabelSymbolizer implements LabelSymbolizer {
         // ctx.lineTo(dx, dy);
         // ctx.strokeStyle = "red";
         // ctx.stroke();
-        ctx.rotate(Math.atan2(dy, dx));
-        if (dx < 0) {
-          ctx.scale(-1, -1);
-          ctx.translate(-width, 0);
-        }
         let heightPlacement = 0;
         if (this.position === LineLabelPlacement.Below)
-          heightPlacement += height;
+          heightPlacement = height;
         else if (this.position === LineLabelPlacement.Center)
-          heightPlacement += height / 2;
+          heightPlacement = height / 2;
+        // Compute the angle between the positive X axis and
+        // the point (dx, -dy). Notice that we need to change
+        // dy sign in order to account for the sign change of
+        // the canvas reference system respect to cartesian
+        // coordinate system.
+        // Once we get that angle, we substract PI/2 rad to the
+        // angle to create a perpendicular vector that will be
+        // used for the label placement translation
+        const angle = Math.atan2(-dy, dx);
         ctx.translate(
-          0,
-          heightPlacement - this.offset.get(layout.zoom, feature)
+          Math.cos(angle - Math.PI / 2) * heightPlacement,
+          -Math.sin(angle - Math.PI / 2) * heightPlacement
         );
+        ctx.rotate(-angle);
+        if (dx < 0) {
+          ctx.scale(-1, -1);
+          ctx.translate(-width, 2 * heightPlacement);
+        }
+        ctx.translate(0, -this.offset.get(layout.zoom, feature));
         ctx.font = font;
         let lineWidth = this.width.get(layout.zoom, feature);
         if (lineWidth) {

--- a/test/line.test.ts
+++ b/test/line.test.ts
@@ -14,8 +14,7 @@ test("simple line labeler", async () => {
   let results = simpleLabel(mls, 10, 250, 0);
   assert.deepEqual(results[0].start, { x: 0, y: 0 });
   assert.deepEqual(results[0].end, { x: 10, y: 0 });
-})
-
+});
 
 test("simple line labeler tolerance", async () => {
   mls = [


### PR DESCRIPTION
Adds a `position` attribute to `LineLabelSymbolizer` which can be `LineLabelPlacement.Above`, `LineLabelPlacement.Center` or `LineLabelPlacement.Below` changing the label placement in respect to the line center.

Above
![image](https://user-images.githubusercontent.com/2301378/137920125-332332ed-9c16-40dd-8ee5-70b534fae540.png)

Center
![image](https://user-images.githubusercontent.com/2301378/137920247-adcccd25-70af-4996-8a12-09ed0d6017af.png)

Below
![image](https://user-images.githubusercontent.com/2301378/137920372-caa44504-b0b7-443e-b252-345fee411fd3.png)
