### PR TITLE
Adds CurvedLineSymbolizer

### DIFF
--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -18,6 +18,8 @@ export interface Label {
   draw: (ctx: any, drawExtra?: DrawExtra) => void;
   deduplicationKey?: string;
   deduplicationDistance?: number;
+  allowCollisions?: boolean;
+  collisionKey?: string;
 }
 
 export interface IndexedLabel {
@@ -135,7 +137,14 @@ export class Index {
   public labelCollides(label: Label, order: number): boolean {
     for (let bbox of label.bboxes) {
       for (let match of this.tree.search(bbox)) {
-        if (match.indexed_label.order <= order) return true;
+        if (match.indexed_label.order <= order) {
+          if (
+            !!label.allowCollisions &&
+            match.collisionKey === label.collisionKey
+          )
+            return false;
+          return true;
+        }
       }
     }
     return false;
@@ -187,6 +196,7 @@ export class Index {
     for (let bbox of label.bboxes) {
       var b: any = bbox;
       b.indexed_label = indexed_label;
+      if (label.collisionKey) b.collisionKey = label.collisionKey;
       this.tree.insert(b);
 
       if (bbox.minX < 0) wrapsLeft = true;

--- a/src/line.ts
+++ b/src/line.ts
@@ -98,7 +98,8 @@ export function simpleLabel(
   mls: any,
   minimum: number,
   repeatDistance: number,
-  cellSize: number
+  cellSize: number,
+  overflowAllowed = false
 ): LabelCandidate[] {
   let longestStart;
   let longestEnd;
@@ -111,7 +112,7 @@ export function simpleLabel(
   for (let ls of mls) {
     let segments = linelabel(ls, Math.PI / 90); // 2 degrees, close to a straight line
     for (let segment of segments) {
-      if (segment.length >= minimum + cellSize) {
+      if (segment.length >= minimum + cellSize || overflowAllowed) {
         let start = new Point(
           ls[segment.beginIndex].x,
           ls[segment.beginIndex].y
@@ -125,8 +126,8 @@ export function simpleLabel(
         // offset from the start by cellSize to allow streets that meet at right angles
         // to both be labeled.
         for (
-          var i = cellSize;
-          i < segment.length - minimum;
+          var i = overflowAllowed ? 0 : cellSize;
+          i < segment.length - (overflowAllowed ? 0 : minimum);
           i += repeatDistance
         ) {
           candidates.push({

--- a/src/maths.ts
+++ b/src/maths.ts
@@ -1,0 +1,8 @@
+// @ts-ignore
+import Point from "@mapbox/point-geometry";
+export type Vector = Point;
+
+export const normalize = (v: Vector): Vector => {
+  const vectorMagnitude = Math.hypot(v.x, v.y);
+  return { x: v.x / vectorMagnitude, y: v.y / vectorMagnitude };
+};

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -8,6 +8,7 @@ import { NumberAttr, StringAttr, TextAttr, FontAttr } from "./attribute";
 import { linebreak, isCjk } from "./text";
 import { LabelCandidate, lineCells, simpleLabel } from "./line";
 import { Index, Label, Layout } from "./labeler";
+import { normalize, Vector } from "./maths";
 
 // https://bugs.webkit.org/show_bug.cgi?id=230751
 const MAX_VERTICES_PER_DRAW_CALL = 5400;
@@ -957,6 +958,188 @@ export class LineLabelSymbolizer implements LabelSymbolizer {
     }
 
     return labels;
+  }
+}
+
+export interface LabelCandidateWithText extends LabelCandidate {
+  text: string;
+}
+
+export class CurvedLabelSymbolizer extends LineLabelSymbolizer {
+  constructor(options: any) {
+    super(options);
+  }
+
+  public place(layout: Layout, geom: Point[][], feature: Feature) {
+    let name = this.text.get(layout.zoom, feature);
+    if (this.canBeRendered(name, layout, feature)) {
+      const { width, height, cellSize, font } = this.getTextMetrics(
+        layout,
+        feature
+      );
+      const repeatDistance = this.getRepeatDistance(layout, feature);
+      const labelCandidates = this.curvedLabel(
+        feature,
+        name,
+        layout,
+        geom,
+        repeatDistance,
+        cellSize
+      );
+      if (labelCandidates.length !== 0) {
+        return this.renderLabelCandidates(
+          labelCandidates,
+          (c) => (c as LabelCandidateWithText).text,
+          layout,
+          feature,
+          font,
+          width,
+          height,
+          cellSize,
+          repeatDistance,
+          true
+        );
+      }
+    }
+    return undefined;
+  }
+
+  private curvedLabel(
+    feature: Feature,
+    name: string,
+    layout: Layout,
+    geom: Point[][],
+    repeatDistance: number,
+    cellSize: number
+  ): LabelCandidateWithText[] {
+    const candidates = [];
+    const chars = [...name];
+    const vertices = geom[0];
+    const vectors: Vector[] = [];
+    let totalLineLength = 0;
+
+    // Compute each line segment length and vector
+    const segmentLengths = vertices.slice(0, -1).map((v, i) => {
+      const vector = {
+        x: vertices[i + 1].x - vertices[i].x,
+        y: vertices[i + 1].y - vertices[i].y,
+      };
+      vectors.push(vector);
+      const length = Math.hypot(vector.x, vector.y);
+      totalLineLength += length;
+      return length;
+    });
+    const font = this.font.get(layout.zoom, feature);
+    layout.scratch.font = font;
+    const totalTextLength = layout.scratch.measureText(name).width;
+
+    //Early return if text doesn't fit in line
+    if (totalLineLength < totalTextLength) return [];
+
+    // Compute an array that contains the length between the text start and
+    // char i on the i-th position. We compute the metrics of all the text
+    // instead of doing it char by char to account for text-spacing
+    const accumTextMetrics: number[] = [];
+    for (let charIdx = 0; charIdx < chars.length - 1; ++charIdx) {
+      const currentTextMetrics = layout.scratch.measureText(
+        name.slice(0, charIdx + 1)
+      );
+      accumTextMetrics.push(currentTextMetrics.width);
+    }
+    accumTextMetrics.push(totalTextLength);
+
+    let currentSegmentIdx = 0;
+    let distanceBetweenRenders = repeatDistance;
+    let remainingTextToRenderCharIdx = 0;
+    let lastRenderedLength = 0;
+    let remainingLineLength = totalLineLength;
+    for (; currentSegmentIdx < vertices.length - 1; ++currentSegmentIdx) {
+      remainingLineLength -= segmentLengths[currentSegmentIdx];
+      if (distanceBetweenRenders >= repeatDistance) {
+        if (totalTextLength < segmentLengths[currentSegmentIdx]) {
+          // The whole text fits into this segment, create
+          // candidates on it
+          const segmentCandidates: LabelCandidate[] = simpleLabel(
+            [[vertices[currentSegmentIdx], vertices[currentSegmentIdx + 1]]],
+            totalTextLength,
+            repeatDistance,
+            cellSize
+          );
+          const segmentCandidatesWithText = segmentCandidates.map((c) => {
+            return {
+              ...c,
+              text: name,
+            };
+          });
+          candidates.push(...segmentCandidatesWithText);
+        } else if (
+          remainingTextToRenderCharIdx < chars.length &&
+          remainingLineLength >= totalTextLength
+        ) {
+          // There are chars pending to render into this segment and
+          // there's enough place for another text instance
+          let breakCharIdx = remainingTextToRenderCharIdx;
+          const startMetrics =
+            accumTextMetrics[remainingTextToRenderCharIdx - 1] || 0;
+          // Find the character where the text needs to be split. In order to
+          // minimize gaps between segments we always render an extra character.
+          // This means that on the next segment we'll need to take that into account
+          while (
+            accumTextMetrics[breakCharIdx] - startMetrics <
+              segmentLengths[currentSegmentIdx] &&
+            breakCharIdx < chars.length - 1
+          ) {
+            breakCharIdx++;
+          }
+          // Add the extra space on the old segment into the new one
+          // as the initial offset on the starting point so letters don't overlap
+          const extraSpaceOnSegment = Math.max(
+            0,
+            lastRenderedLength - (segmentLengths[currentSegmentIdx - 1] || 0)
+          );
+          lastRenderedLength =
+            accumTextMetrics[breakCharIdx] -
+            (accumTextMetrics[remainingTextToRenderCharIdx - 1] || 0);
+          const offsetX = extraSpaceOnSegment;
+          const offsetY = extraSpaceOnSegment;
+          const normalizedVector = normalize(vectors[currentSegmentIdx]);
+          const start = {
+            x: vertices[currentSegmentIdx].x + offsetX * normalizedVector.x,
+            y: vertices[currentSegmentIdx].y + offsetY * normalizedVector.y,
+          };
+          // Create candidates on this line using the initial point
+          // computed before as the initial vertex
+          const textToRender = name.slice(
+            remainingTextToRenderCharIdx,
+            breakCharIdx + 1
+          );
+          const segmentCandidates: LabelCandidate[] = simpleLabel(
+            [[start, vertices[currentSegmentIdx + 1]]],
+            accumTextMetrics[breakCharIdx] -
+              (accumTextMetrics[remainingTextToRenderCharIdx - 1] || 0),
+            repeatDistance,
+            cellSize,
+            true
+          );
+          const segmentCandidatesWithText = segmentCandidates.map((c) => {
+            return {
+              ...c,
+              text: textToRender,
+            };
+          });
+          candidates.push(...segmentCandidatesWithText);
+          remainingTextToRenderCharIdx = breakCharIdx + 1;
+          if (remainingTextToRenderCharIdx >= chars.length) {
+            distanceBetweenRenders = 0;
+            lastRenderedLength = 0;
+            remainingTextToRenderCharIdx = 0;
+          }
+        } else {
+          distanceBetweenRenders += segmentLengths[currentSegmentIdx];
+        }
+      }
+    }
+    return candidates;
   }
 }
 


### PR DESCRIPTION
Adds a new symbolizer to be used with curved labels.
Supports the same properties as `LineLabelSymbolizer`

```typescript
{
    //water-line-label
    dataLayer: `natural_label`,
    symbolizer: new CurvedLabelSymbolizer({
      label_props: ["name_en", "name"],
      fill: params.waterPointLabelColor1,
      fontFamily: SansSerifRegular.fontFamily,
      fontSize: 20,
      letterSpacing: 0.25,
    }),
  },
```

![image](https://user-images.githubusercontent.com/2301378/138725018-41a9cdce-9b5e-4ce5-9532-bf84af3dee87.png)

![image](https://user-images.githubusercontent.com/2301378/138725131-d1a587c0-7093-4c14-8d0e-4b81640a3c93.png)

Closes [issue #38](https://github.com/felt/protomaps-felt/issues/38)