### PR TITLE
feat(dash): Makes it evaluable

### DIFF
--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -142,3 +142,25 @@ export class FontAttr {
     }
   }
 }
+
+export class ArrayAttr {
+  value:
+    | string[]
+    | number[]
+    | ((z: number, f?: Feature) => string[] | number[]);
+  per_feature: boolean;
+
+  constructor(c: any, defaultValue: number[] = []) {
+    this.value = c || defaultValue;
+    this.per_feature =
+      typeof this.value == "function" && this.value.length == 2;
+  }
+
+  public get(z: number, f?: Feature): string[] | number[] {
+    if (typeof this.value == "function") {
+      return this.value(z, f);
+    } else {
+      return this.value;
+    }
+  }
+}

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -4,7 +4,13 @@ import UnitBezier from "@mapbox/unitbezier";
 import { GeomType, Feature, Bbox } from "./tilecache";
 // @ts-ignore
 import polylabel from "polylabel";
-import { NumberAttr, StringAttr, TextAttr, FontAttr } from "./attribute";
+import {
+  NumberAttr,
+  StringAttr,
+  TextAttr,
+  FontAttr,
+  ArrayAttr,
+} from "./attribute";
 import { linebreak, isCjk } from "./text";
 import { lineCells, simpleLabel } from "./line";
 import { Index, Label, Layout } from "./labeler";
@@ -217,7 +223,7 @@ export class LineSymbolizer implements PaintSymbolizer {
   color: StringAttr;
   width: NumberAttr;
   opacity: NumberAttr;
-  dash: any;
+  dash: ArrayAttr;
   dashColor: StringAttr;
   dashWidth: NumberAttr;
   skip: boolean;
@@ -229,14 +235,14 @@ export class LineSymbolizer implements PaintSymbolizer {
     this.color = new StringAttr(options.color, "black");
     this.width = new NumberAttr(options.width);
     this.opacity = new NumberAttr(options.opacity);
-    this.dash = options.dash;
+    this.dash = new ArrayAttr(options.dash);
     this.dashColor = new StringAttr(options.dashColor, "black");
     this.dashWidth = new NumberAttr(options.dashWidth);
     this.lineCap = new StringAttr(options.lineCap, "butt");
     this.lineJoin = new StringAttr(options.lineJoin, "miter");
     this.skip = false;
     this.per_feature =
-      this.dash ||
+      this.dash.per_feature ||
       this.color.per_feature ||
       this.opacity.per_feature ||
       this.width.per_feature ||
@@ -269,8 +275,10 @@ export class LineSymbolizer implements PaintSymbolizer {
         if (this.per_feature) {
           ctx.lineWidth = this.dashWidth.get(z, f);
           ctx.strokeStyle = this.dashColor.get(z, f);
+          ctx.setLineDash(this.dash.get(z, f));
+        } else {
+          ctx.setLineDash(this.dash.get(z));
         }
-        ctx.setLineDash(this.dash);
         ctx.stroke();
         ctx.restore();
       } else {

--- a/test/attribute.test.ts
+++ b/test/attribute.test.ts
@@ -1,4 +1,10 @@
-import { NumberAttr, StringAttr, FontAttr, TextAttr } from "../src/attribute";
+import {
+  NumberAttr,
+  StringAttr,
+  FontAttr,
+  TextAttr,
+  ArrayAttr,
+} from "../src/attribute";
 import { GeomType } from "../src/tilecache";
 import assert from "assert";
 import baretest from "baretest";
@@ -183,6 +189,39 @@ test("textattr", async () => {
   });
   assert.equal(t.get(0, { props: { name: "台北", abbr: "TPE" } }), "TPE");
   assert.equal(t.get(9, { props: { name: "台北", abbr: "TPE" } }), "台北");
+});
+
+test("arrayattr", async () => {
+  let n = new ArrayAttr(undefined, undefined);
+  assert.equal(n.get().length, 0);
+
+  n = new ArrayAttr(2, undefined);
+  assert.equal(n.get(), 2);
+
+  n = new ArrayAttr(undefined, 3);
+  assert.equal(n.get(), 3);
+
+  n = new ArrayAttr(undefined, 0);
+  assert.equal(n.get(), 0);
+
+  n = new ArrayAttr((z, f) => {
+    return [z, z];
+  }, 0);
+  assert.equal(n.get(2)[0], 2);
+  assert.equal(n.get(2)[1], 2);
+  assert.equal(n.get(3)[0], 3);
+  assert.equal(n.get(3)[1], 3);
+
+  n = new ArrayAttr(1);
+  assert.equal(n.per_feature, false);
+  n = new ArrayAttr((z) => {
+    return z;
+  });
+  assert.equal(n.per_feature, false);
+  n = new ArrayAttr((z, f) => {
+    return z;
+  });
+  assert.equal(n.per_feature, true);
 });
 
 export default test;


### PR DESCRIPTION
Converts dash to an evaluated property so you can do something like the following:
```
dash: (z) => {
        if (z < 5) return [2, 2]
        else return [50, 50]
}
```
Fixes https://github.com/felt/protomaps-felt/issues/52