### PR TITLE
Adds GroupedLineSymbolizer

### DIFF
--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -286,19 +286,13 @@ export class LineSymbolizer implements PaintSymbolizer {
     ctx.save();
     ctx.beginPath();
     setStyle();
-    for (var ls of geom) {
-      // if (vertices_in_path + ls.length > MAX_VERTICES_PER_DRAW_CALL) {
-      //   ctx.stroke();
-      //   vertices_in_path = 0;
-      //   ctx.beginPath();
-      // }
+    geom.forEach((ls) => {
       ctx.moveTo(ls[0].x, ls[0].y);
-      for (var p = 1; p < ls.length; p++) {
-        let pt = ls[p];
+      ls.forEach((pt) => {
         ctx.lineTo(pt.x, pt.y);
-      }
+      });
       vertices_in_path += ls.length;
-    }
+    });
     if (vertices_in_path > 0) ctx.stroke();
     ctx.restore();
   }

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -287,11 +287,11 @@ export class LineSymbolizer implements PaintSymbolizer {
     ctx.beginPath();
     setStyle();
     for (var ls of geom) {
-      if (vertices_in_path + ls.length > MAX_VERTICES_PER_DRAW_CALL) {
-        ctx.stroke();
-        vertices_in_path = 0;
-        ctx.beginPath();
-      }
+      // if (vertices_in_path + ls.length > MAX_VERTICES_PER_DRAW_CALL) {
+      //   ctx.stroke();
+      //   vertices_in_path = 0;
+      //   ctx.beginPath();
+      // }
       ctx.moveTo(ls[0].x, ls[0].y);
       for (var p = 1; p < ls.length; p++) {
         let pt = ls[p];

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -264,46 +264,43 @@ export class LineSymbolizer implements PaintSymbolizer {
   public draw(ctx: any, geom: Point[][], z: number, f: Feature) {
     if (this.skip) return;
 
-    let strokePath = () => {
+    const setStyle = () => {
       if (this.per_feature) {
         ctx.globalAlpha = this.opacity.get(z, f);
         ctx.lineCap = this.lineCap.get(z, f);
         ctx.lineJoin = this.lineJoin.get(z, f);
       }
       if (this.dash) {
-        ctx.save();
         ctx.lineWidth = this.dashWidth.get(z, f);
         ctx.strokeStyle = this.dashColor.get(z, f);
         ctx.setLineDash(this.dash.get(z, f));
-        ctx.stroke();
-        ctx.restore();
       } else {
-        ctx.save();
         if (this.per_feature) {
           ctx.lineWidth = this.width.get(z, f);
           ctx.strokeStyle = this.color.get(z, f);
         }
-        ctx.stroke();
-        ctx.restore();
       }
     };
 
     var vertices_in_path = 0;
+    ctx.save();
     ctx.beginPath();
+    setStyle();
     for (var ls of geom) {
       if (vertices_in_path + ls.length > MAX_VERTICES_PER_DRAW_CALL) {
-        strokePath();
+        ctx.stroke();
         vertices_in_path = 0;
         ctx.beginPath();
       }
-      for (var p = 0; p < ls.length; p++) {
+      ctx.moveTo(ls[0].x, ls[0].y);
+      for (var p = 1; p < ls.length; p++) {
         let pt = ls[p];
-        if (p == 0) ctx.moveTo(pt.x, pt.y);
-        else ctx.lineTo(pt.x, pt.y);
+        ctx.lineTo(pt.x, pt.y);
       }
       vertices_in_path += ls.length;
     }
-    if (vertices_in_path > 0) strokePath();
+    if (vertices_in_path > 0) ctx.stroke();
+    ctx.restore();
   }
 }
 

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -287,13 +287,13 @@ export class LineSymbolizer implements PaintSymbolizer {
     ctx.beginPath();
     setStyle();
     geom.forEach((ls) => {
-      ctx.moveTo(ls[0].x, ls[0].y);
+      //ctx.moveTo(ls[0].x, ls[0].y);
       ls.forEach((pt) => {
-        ctx.lineTo(pt.x, pt.y);
+        //ctx.lineTo(pt.x, pt.y);
       });
       vertices_in_path += ls.length;
     });
-    if (vertices_in_path > 0) ctx.stroke();
+    //if (vertices_in_path > 0) ctx.stroke();
     ctx.restore();
   }
 }

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -283,18 +283,24 @@ export class LineSymbolizer implements PaintSymbolizer {
     };
 
     var vertices_in_path = 0;
-    //ctx.save();
+    ctx.save();
     ctx.beginPath();
-    //setStyle();
-    geom.forEach((ls) => {
+    setStyle();
+    for (var ls of geom) {
+      if (vertices_in_path + ls.length > MAX_VERTICES_PER_DRAW_CALL) {
+        ctx.stroke();
+        vertices_in_path = 0;
+        ctx.beginPath();
+      }
       ctx.moveTo(ls[0].x, ls[0].y);
-      ls.forEach((pt) => {
-        ctx.lineTo((0.5 + pt.x) << 0, (0.5 + pt.y) << 0);
-      });
+      for (var p = 1; p < ls.length; p++) {
+        let pt = ls[p];
+        ctx.lineTo(pt.x, pt.y);
+      }
       vertices_in_path += ls.length;
-    });
+    }
     if (vertices_in_path > 0) ctx.stroke();
-    //ctx.restore();
+    ctx.restore();
   }
 }
 

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -289,7 +289,7 @@ export class LineSymbolizer implements PaintSymbolizer {
     geom.forEach((ls) => {
       ctx.moveTo(ls[0].x, ls[0].y);
       ls.forEach((pt) => {
-        ctx.lineTo(pt.x, pt.y);
+        ctx.lineTo((0.5 + pt.x) << 0, (0.5 + pt.y) << 0);
       });
       vertices_in_path += ls.length;
     });

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -283,18 +283,18 @@ export class LineSymbolizer implements PaintSymbolizer {
     };
 
     var vertices_in_path = 0;
-    ctx.save();
+    //ctx.save();
     ctx.beginPath();
-    setStyle();
+    //setStyle();
     geom.forEach((ls) => {
-      //ctx.moveTo(ls[0].x, ls[0].y);
+      ctx.moveTo(ls[0].x, ls[0].y);
       ls.forEach((pt) => {
-        //ctx.lineTo(pt.x, pt.y);
+        ctx.lineTo(pt.x, pt.y);
       });
       vertices_in_path += ls.length;
     });
-    //if (vertices_in_path > 0) ctx.stroke();
-    ctx.restore();
+    if (vertices_in_path > 0) ctx.stroke();
+    //ctx.restore();
   }
 }
 


### PR DESCRIPTION
Adds a drawGrouped method to PaintSymbolizer that receives all the features of a tile.
That allows creating more performant draw functions that reduce greatly the number of draw calls.
In the example below we go from 80K draw calls to 66 when viewing the trails dataset at zoom level 8 on full-screen.
![image](https://user-images.githubusercontent.com/2301378/142439543-48959e37-d445-4471-b7ca-891a98af9970.png)

Opening this PR to discuss the approach taken here and to see if there are better ways to integrate it inn protomaps
