### PR TITLE
fix(circle): Renders stroke instead of two fills

### DIFF
--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -532,10 +532,11 @@ export class CircleSymbolizer implements LabelSymbolizer, PaintSymbolizer {
     let radius = this.radius.get(z, f);
     let width = this.width.get(z, f);
     if (width > 0) {
-      ctx.fillStyle = this.stroke.get(z, f);
+      ctx.strokeStyle = this.stroke.get(z, f);
+      ctx.lineWidth = width;
       ctx.beginPath();
-      ctx.arc(geom[0][0].x, geom[0][0].y, radius + width, 0, 2 * Math.PI);
-      ctx.fill();
+      ctx.arc(geom[0][0].x, geom[0][0].y, radius + width / 2, 0, 2 * Math.PI);
+      ctx.stroke();
     }
 
     ctx.fillStyle = this.fill.get(z, f);


### PR DESCRIPTION
This enables using transparent fill colors
Before
![image](https://user-images.githubusercontent.com/2301378/184172760-1bd6f1de-9573-41ed-b323-cd41a04bdcb4.png)

After
![image](https://user-images.githubusercontent.com/2301378/184172903-cf381902-56f2-4893-bd20-d1376c0c439a.png)
