### PR TITLE
feat(query): Gets all features with a given id

### DIFF
--- a/src/frontends/leaflet.ts
+++ b/src/frontends/leaflet.ts
@@ -11,7 +11,7 @@ import { dark } from "../default_style/dark";
 import { paintRules, labelRules } from "../default_style/style";
 import { ProtomapsEvent } from "../events";
 import { LabelPickedFeature, PickedFeature } from "../tilecache";
-import { BasemapLayerSourceName, Bbox } from "..";
+import { BasemapLayerSourceName, Bbox, Feature } from "..";
 
 const DefaultLeafletTileSize = 256;
 
@@ -442,23 +442,25 @@ const leafletLayer = (options: any): any => {
     public queryFeature(srcName: string, dataLayer: string, id: number) {
       const view = this.views.get(srcName);
       if (view) {
-        const feature = view.queryFeature(dataLayer, id);
-        if (feature) {
-          const features = this.getRenderedFeatures(
+        const features = view.queryFeature(dataLayer, id);
+        if (features.length !== 0) {
+          const renderedFeatures = this.getRenderedFeatures(
             {
-              [dataLayer]: [
-                {
-                  feature: feature,
-                  layerName: dataLayer,
-                  tileX: 0,
-                  tileY: 0,
-                  zoom: 0,
-                },
-              ],
+              [dataLayer]: features.map(
+                (f: { feature: Feature; tileIndex: number[] }) => {
+                  return {
+                    feature: f.feature,
+                    layerName: dataLayer,
+                    tileX: f.tileIndex[0],
+                    tileY: f.tileIndex[1],
+                    zoom: f.tileIndex[2],
+                  };
+                }
+              ),
             },
             srcName
           );
-          if (features.length !== 0) return features[0];
+          return renderedFeatures;
         }
       }
     }

--- a/src/tilecache.ts
+++ b/src/tilecache.ts
@@ -461,7 +461,7 @@ export class TileCache {
   }
 
   public queryFeature(dataLayer: string, id: number) {
-    let feature = null;
+    let features: { feature: Feature; tileIndex: number[] }[] = [];
     let tileIndex = [0, 0, 0];
     for (const [tile, entry] of this.cache.entries()) {
       const index = tile.split(":").map((i) => parseInt(i));
@@ -469,13 +469,13 @@ export class TileCache {
         const featureInTile = (entry.data.get(dataLayer) || []).find(
           (f) => f.id === id
         );
-        if (featureInTile && index[2] > tileIndex[2]) {
-          feature = featureInTile;
+        if (featureInTile !== undefined && index[2] > tileIndex[2]) {
+          features.push({ feature: featureInTile, tileIndex: index });
           tileIndex = index;
         }
       }
     }
-    return feature;
+    return features;
   }
 
   public async get(c: Zxy): Promise<Map<string, Feature[]>> {


### PR DESCRIPTION
Previously, when looking for a feature with a given id we only got the first one. 
With this change we get all the features on a layer with that id which accounts for geometries crossing tile boundaries