### PR TITLE
feat(simplification): Exposes shouldSimplify and shouldSplit

### DIFF
--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -16,6 +16,12 @@ import { lineCells, simpleLabel } from "./line";
 import { Label, Layout } from "./labeler";
 
 // https://bugs.webkit.org/show_bug.cgi?id=230751
+// This ^ has now been resolved (see https://bugs.webkit.org/show_bug.cgi?id=231157)
+// PmtilesSource and ZxySource now expose a shouldSimplify boolean
+// flag that defaults to false that disables the simplification
+// Similarly, Polygon and Line symbolizers now expose a shouldSplit boolean
+// flag that defaults to false that disables splitting features
+// in multiple draw calls
 export const MAX_VERTICES_PER_DRAW_CALL = 4000;
 
 export interface GroupedGeometries {

--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -78,6 +78,7 @@ export class PolygonSymbolizer implements PaintSymbolizer {
   width: NumberAttr;
   per_feature: boolean;
   do_stroke: boolean;
+  shouldSplit: boolean;
 
   constructor(options: any) {
     this.pattern = options.pattern;
@@ -92,6 +93,7 @@ export class PolygonSymbolizer implements PaintSymbolizer {
       this.width.per_feature ||
       options.per_feature;
     this.do_stroke = false;
+    this.shouldSplit = options.shouldSplit ?? false;
   }
 
   public before(ctx: any, z: number) {
@@ -132,7 +134,10 @@ export class PolygonSymbolizer implements PaintSymbolizer {
     var vertices_in_path = 0;
     ctx.beginPath();
     for (var poly of geom) {
-      if (vertices_in_path + poly.length > MAX_VERTICES_PER_DRAW_CALL) {
+      if (
+        vertices_in_path + poly.length > MAX_VERTICES_PER_DRAW_CALL &&
+        this.shouldSplit
+      ) {
         drawPath();
         vertices_in_path = 0;
         ctx.beginPath();
@@ -155,6 +160,7 @@ export class GroupedPolygonSymbolizer implements PaintSymbolizer {
   stroke: StringAttr;
   width: NumberAttr;
   do_stroke: boolean;
+  shouldSplit: boolean;
 
   constructor(options: any) {
     this.pattern = options.pattern;
@@ -163,6 +169,7 @@ export class GroupedPolygonSymbolizer implements PaintSymbolizer {
     this.stroke = new StringAttr(options.stroke, "black");
     this.width = new NumberAttr(options.width, 0);
     this.do_stroke = false;
+    this.shouldSplit = options.shouldSplit ?? false;
   }
 
   public before(ctx: any, z: number) {
@@ -200,7 +207,10 @@ export class GroupedPolygonSymbolizer implements PaintSymbolizer {
       if (inside(feature) && filter(feature)) {
         const geom = transform(feature.geom);
         const verticesInGeom = geom.reduce((sum, r) => sum + r.length, 0);
-        if (verticesInPath + verticesInGeom > MAX_VERTICES_PER_DRAW_CALL) {
+        if (
+          verticesInPath + verticesInGeom > MAX_VERTICES_PER_DRAW_CALL &&
+          this.shouldSplit
+        ) {
           drawPath();
           ctx.beginPath();
           verticesInPath = 0;
@@ -319,6 +329,7 @@ export class LineSymbolizer implements PaintSymbolizer {
   per_feature: boolean;
   lineCap: StringAttr;
   lineJoin: StringAttr;
+  shouldSplit: boolean;
 
   constructor(options: any) {
     this.color = new StringAttr(options.color, "black");
@@ -338,6 +349,7 @@ export class LineSymbolizer implements PaintSymbolizer {
       this.lineCap.per_feature ||
       this.lineJoin.per_feature ||
       options.per_feature;
+    this.shouldSplit = options.shouldSplit ?? false;
   }
 
   public before(ctx: any, z: number) {
@@ -385,7 +397,10 @@ export class LineSymbolizer implements PaintSymbolizer {
     ctx.beginPath();
     setStyle();
     for (var ls of geom) {
-      if (vertices_in_path + ls.length > MAX_VERTICES_PER_DRAW_CALL) {
+      if (
+        vertices_in_path + ls.length > MAX_VERTICES_PER_DRAW_CALL &&
+        this.shouldSplit
+      ) {
         ctx.stroke();
         vertices_in_path = 0;
         ctx.beginPath();
@@ -413,6 +428,7 @@ export class GroupedLineSymbolizer implements PaintSymbolizer {
   per_feature: boolean;
   lineCap: StringAttr;
   lineJoin: StringAttr;
+  shouldSplit: boolean;
 
   constructor(options: any) {
     this.color = new StringAttr(options.color, "black");
@@ -425,6 +441,7 @@ export class GroupedLineSymbolizer implements PaintSymbolizer {
     this.lineJoin = new StringAttr(options.lineJoin, "miter");
     this.skip = false;
     this.per_feature = false;
+    this.shouldSplit = false;
   }
 
   public before(ctx: any, z: number) {
@@ -464,7 +481,10 @@ export class GroupedLineSymbolizer implements PaintSymbolizer {
       if (inside(feature) && filter(feature)) {
         const geom = transform(feature.geom);
         geom.forEach((ls) => {
-          if (verticesInPath + ls.length > MAX_VERTICES_PER_DRAW_CALL) {
+          if (
+            verticesInPath + ls.length > MAX_VERTICES_PER_DRAW_CALL &&
+            this.shouldSplit
+          ) {
             ctx.stroke();
             ctx.beginPath();
             verticesInPath = 0;

--- a/src/view.ts
+++ b/src/view.ts
@@ -278,21 +278,24 @@ export const sourceToView = (o: any) => {
       o.url,
       o.shouldCancelZooms ?? true,
       o.headers,
-      o.subdomains
+      o.subdomains,
+      o.shouldSimplify
     );
   } else if (o.url.endsWith(".pmtiles")) {
     source = new PmtilesSource(
       o.url,
       o.shouldCancelZooms ?? true,
       o.headers,
-      o.subdomains
+      o.subdomains,
+      o.shouldSimplify
     );
   } else {
     source = new ZxySource(
       o.url,
       o.shouldCancelZooms ?? true,
       o.headers,
-      o.subdomains
+      o.subdomains,
+      o.shouldSimplify
     );
   }
   const cache = new TileCache(source, (256 * 1) << level_diff);


### PR DESCRIPTION
As https://bugs.webkit.org/show_bug.cgi?id=230751 has been fixed for a while we could remove the simplification and draw call splitting steps while rendering polygons and lines.
Instead of doing that, this PR exposes `shouldSimplify` in the source object and `shouldSplit` in the polygon and lines symbolizes. Both now default to false but can be set to true to keep the old behaviour